### PR TITLE
엔티티 설계 및 관계 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,14 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.1.1'
+    id 'org.springframework.boot' version '2.7.10'
     id 'io.spring.dependency-management' version '1.1.0'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com'
@@ -23,19 +30,47 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+//    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
+//    testImplementation 'org.springframework.security:spring-security-test'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.security:spring-security-crypto:5.7.1'
+
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
 }

--- a/src/main/java/com/blogifyserver/config/PassEncoderConfig.java
+++ b/src/main/java/com/blogifyserver/config/PassEncoderConfig.java
@@ -1,0 +1,16 @@
+package com.blogifyserver.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PassEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/blogifyserver/config/QueryDslConfig.java
+++ b/src/main/java/com/blogifyserver/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.blogifyserver.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/src/main/java/com/blogifyserver/entity/Blog.java
+++ b/src/main/java/com/blogifyserver/entity/Blog.java
@@ -1,0 +1,32 @@
+package com.blogifyserver.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+public class Blog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long blogNum;
+
+
+    @OneToOne
+    @JoinColumn(name = "member_num")
+    private Member member;
+
+    @Column
+    private String description;
+
+    @OneToMany(mappedBy = "blog", cascade = CascadeType.ALL)
+    private List<Category> categories;
+
+    public void addCategory(Category category) {
+        categories.add(category);
+        category.setBlog(this);
+    }
+}

--- a/src/main/java/com/blogifyserver/entity/Category.java
+++ b/src/main/java/com/blogifyserver/entity/Category.java
@@ -1,0 +1,34 @@
+package com.blogifyserver.entity;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.util.List;
+
+
+@Entity
+@Getter
+@Setter
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long categoryNum;
+
+    @Column
+    private String name;
+
+    @ManyToOne
+    @JoinColumn(name = "blog_num")
+    private Blog blog;
+
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
+    private List<Post> posts;
+
+    public void addPost(Post post) {
+        posts.add(post);
+        post.setCategory(this);
+    }
+}

--- a/src/main/java/com/blogifyserver/entity/Follows.java
+++ b/src/main/java/com/blogifyserver/entity/Follows.java
@@ -1,0 +1,22 @@
+package com.blogifyserver.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Setter
+public class Follows {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long followsNum;
+    @ManyToOne(cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "follower_num")
+    private Member follower;
+
+    @ManyToOne(cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "followed_num")
+    private Member followed;
+}

--- a/src/main/java/com/blogifyserver/entity/Member.java
+++ b/src/main/java/com/blogifyserver/entity/Member.java
@@ -1,0 +1,42 @@
+package com.blogifyserver.entity;
+
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Service;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Setter
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long memberNum;
+
+    @Column(length = 64, unique = true)
+    private String email;
+
+    @Column(length = 128)
+    private String pass;
+
+    @Column(length = 16)
+    private String nickName;
+
+    @Column
+    private String profileImg;
+
+    @OneToOne(cascade = CascadeType.ALL, mappedBy = "member")
+    private Blog blog;
+
+    public void setBlog(Blog blog) {
+        this.blog = blog;
+        blog.setMember(this);
+    }
+
+
+}
+
+

--- a/src/main/java/com/blogifyserver/entity/Post.java
+++ b/src/main/java/com/blogifyserver/entity/Post.java
@@ -1,0 +1,51 @@
+package com.blogifyserver.entity;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+public class Post {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long postNum;
+
+    @Column
+    private int hit;
+
+    @Column
+    private int recommend;
+
+    @Column
+    private String title;
+
+    @Column
+    private String content;
+
+    @ManyToOne
+    @JoinColumn(name = "category_num")
+    private Category category;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<Reply> replies;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<PostImg> postImgs;
+
+    public void addPostImg(PostImg postImg) {
+        postImgs.add(postImg);
+        postImg.setPost(this);
+    }
+
+    public void addReply(Reply reply) {
+        replies.add(reply);
+        reply.setPost(this);
+    }
+
+
+}

--- a/src/main/java/com/blogifyserver/entity/PostImg.java
+++ b/src/main/java/com/blogifyserver/entity/PostImg.java
@@ -1,0 +1,23 @@
+package com.blogifyserver.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Setter
+public class PostImg {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long imgNum;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Column
+    private String fileName;
+}

--- a/src/main/java/com/blogifyserver/entity/Reply.java
+++ b/src/main/java/com/blogifyserver/entity/Reply.java
@@ -1,0 +1,29 @@
+package com.blogifyserver.entity;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Setter
+public class Reply {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long replyNum;
+
+    @ManyToOne
+    @JoinColumn(name = "post_num")
+    private Post post;
+
+    @Column
+    private String comment;
+
+    @ManyToOne
+    @JoinColumn(name = "member_num")
+    private Member member;
+
+}

--- a/src/main/java/com/blogifyserver/member/MemberController.java
+++ b/src/main/java/com/blogifyserver/member/MemberController.java
@@ -1,0 +1,51 @@
+package com.blogifyserver.member;
+
+
+import com.blogifyserver.entity.Member;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/member")
+public class MemberController {
+    final MemberService service;
+
+    public MemberController(MemberService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/signUp")
+    public String signUp(Member member) {
+        if (service.signUp(member)) {
+            return "OK";
+        } else {
+            return "FALSE";
+        }
+    }
+
+    @PostMapping("/emailCheck")
+    public String emailCheck(@RequestBody String email) {
+        if (service.emailCheck(email)) {
+            return "OK";
+        } else {
+            return "FALSE";
+        }
+    }
+
+    @PostMapping("/nickNameCheck")
+    public String nickNameCheck(@RequestBody String nickName) {
+        if (service.nickNameCheck(nickName)) {
+            return "OK";
+        } else {
+            return "FALSE";
+        }
+    }
+
+    @GetMapping("/remove")
+    public String remove(){
+        service.remove();
+        return "cxc";
+    }
+}

--- a/src/main/java/com/blogifyserver/member/MemberCustomRepository.java
+++ b/src/main/java/com/blogifyserver/member/MemberCustomRepository.java
@@ -1,0 +1,10 @@
+package com.blogifyserver.member;
+
+import com.blogifyserver.entity.Member;
+
+public interface MemberCustomRepository {
+
+    boolean nickNameCheck(String nickName);
+
+    boolean emailCheck(String email);
+}

--- a/src/main/java/com/blogifyserver/member/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/blogifyserver/member/MemberCustomRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.blogifyserver.member;
+
+import com.blogifyserver.entity.Member;
+import com.blogifyserver.entity.QMember;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+
+import java.util.List;
+
+import static com.blogifyserver.entity.QMember.member;
+
+@Repository
+public class MemberCustomRepositoryImpl implements MemberCustomRepository {
+    public final JPAQueryFactory queryFactory;
+
+    public MemberCustomRepositoryImpl(EntityManager entityManager) {
+        this.queryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public boolean nickNameCheck(String nickName) {
+        long count = queryFactory.selectOne()
+                .from(member)
+                .where(member.nickName.eq(nickName))
+                .fetchCount();
+        return count > 0;
+    }
+
+    @Override
+    public boolean emailCheck(String email) {
+        long count = queryFactory.selectOne()
+                .from(member)
+                .where(member.email.eq(email))
+                .fetchCount();
+        return count > 0;
+    }
+}

--- a/src/main/java/com/blogifyserver/member/MemberRepository.java
+++ b/src/main/java/com/blogifyserver/member/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.blogifyserver.member;
+
+import com.blogifyserver.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/blogifyserver/member/MemberService.java
+++ b/src/main/java/com/blogifyserver/member/MemberService.java
@@ -1,0 +1,13 @@
+package com.blogifyserver.member;
+
+import com.blogifyserver.entity.Member;
+
+public interface MemberService {
+    boolean signUp(Member member);
+
+    boolean nickNameCheck(String nickName);
+
+    boolean emailCheck(String email);
+
+    void remove();
+}

--- a/src/main/java/com/blogifyserver/member/MemberServiceImpl.java
+++ b/src/main/java/com/blogifyserver/member/MemberServiceImpl.java
@@ -1,0 +1,50 @@
+package com.blogifyserver.member;
+
+
+import com.blogifyserver.entity.Member;
+import org.springframework.stereotype.Service;
+
+import javax.swing.plaf.PanelUI;
+
+@Service
+public class MemberServiceImpl implements MemberService {
+    final MemberRepository repository;
+    final MemberCustomRepository customRepository;
+
+    public MemberServiceImpl(MemberRepository repository, MemberCustomRepository customRepository) {
+
+        this.repository = repository;
+        this.customRepository = customRepository;
+    }
+
+    @Override
+    public boolean signUp(Member member) {
+        String email = member.getEmail();
+        String nickName = member.getNickName();
+
+        if (emailCheck(email) || nickNameCheck(nickName)) {
+            return false;
+        }
+
+        repository.save(member);
+        return true;
+    }
+
+    @Override
+    public boolean emailCheck(String email) {
+
+        return customRepository.emailCheck(email);
+    }
+
+    @Override
+    public void remove() {
+        repository.deleteById(1L);
+    }
+
+    @Override
+    public boolean nickNameCheck(String nickName) {
+
+        return customRepository.nickNameCheck(nickName);
+    }
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,27 @@
-server.port= 4567
+server.port=9090
+
+# Connection
+spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
+spring.datasource.url=jdbc:mariadb://localhost:3306/blogify
+spring.datasource.username=blogify
+spring.datasource.password=1234
+
+# JPA
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.generate-ddl=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDBDialect
+
+# DevTools
+spring.devtools.livereload.enabled=true
+spring.devtools.restart.enabled=false
+spring.thymeleaf.cache=false
+
+#Jpa Logging
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+logging.level.org.hibernate.type=trace
+server.servlet.session.tracking-modes=cookie
+
+#Multipart Max Size
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB


### PR DESCRIPTION
 엔티티 클래스를 추가하여 데이터베이스 테이블과 매핑
 멤버, 블로그, 카테고리, 게시글, 댓글, 첨부파일, 팔로우 엔티티를 설계하고 필요한 속성과 관계를 정의

멤버 회원가입 로직 구현
회원가입 시 이메일과 닉네임 중복 체크를 위한 메소드를 구현.
회원가입 로직에서 이메일과 닉네임 중복 체크를 수행하여 중복된 경우 회원가입을 거부하도록 처리하였습니다. 중복 체크를 위해 QueryDSL을 사용하여 쿼리를 작성하고 실행.
회원가입이 성공한 경우 회원 정보를 저장하고 성공 여부를 반환하는 메소드를 추가.